### PR TITLE
Fixed a typo in the main stylesheet

### DIFF
--- a/DuckDuckGoDeepDark.user.css
+++ b/DuckDuckGoDeepDark.user.css
@@ -560,7 +560,7 @@
 	}
 	.modal--dropdown--settings .settings-dropdown--section .frm__field .frm__switch .frm__switch__label.btn
 	{
-		bacground: var(--hover-background) !important;
+		background: var(--hover-background) !important;
 	}
 	.modal--dropdown--settings .settings-dropdown--section .frm__field .frm__switch .frm__switch__label.btn::after
 	{


### PR DESCRIPTION
Main stylesheet had a typo which Stylus caught when installing the theme. Thought it would be more convenient just to fix it.